### PR TITLE
Add model-config and controller debug-log

### DIFF
--- a/collect.py
+++ b/collect.py
@@ -91,6 +91,8 @@ def main():
 
     command(temppath, 'status', 'juju status --format yaml')
     command(temppath, 'debug-log', 'juju debug-log --replay')
+    command(temppath, 'model-config', 'juju model-config')
+    command(temppath, 'controller-debug-log', 'juju debug-log -m controller --replay')
     command(temppath, 'storage', 'juju storage --format yaml')
     command(temppath, 'storage-pools', 'juju storage-pools --format yaml')
     command(temppath, 'kubernetes-master-config', 'juju config kubernetes-master --format yaml')


### PR DESCRIPTION
While troubleshooting https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/508 I noticed that both of these were missing. They'd be nice to have.