### PR TITLE
Add argparse to pass in a juju controller:model

### DIFF
--- a/collect.py
+++ b/collect.py
@@ -79,7 +79,7 @@ def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument(
         '-m', '--model',
-        help='Model to operate in. Accepts [<controller name>:]<model name>')
+        help='Model to operate in. Accepts <controller name>:<model name>')
     return parser.parse_args()
 
 

--- a/collect.py
+++ b/collect.py
@@ -87,6 +87,9 @@ def main():
     options = parse_args()
     model = ""
     if options.model:
+        if len(model.split(':')) != 2:
+            print("Error determining a controller and a model")
+            return
         model = "-m {}".format(options.model)
 
     tempdir = tempfile.TemporaryDirectory()
@@ -111,7 +114,7 @@ def main():
     command(temppath, 'debug-log', 'juju debug-log {} --replay'.format(model))
     command(temppath, 'model-config', 'juju model-config {}'.format(model))
     command(temppath, 'controller-debug-log',
-            'juju debug-log {} --replay'.format(model))
+            'juju debug-log {} --replay'.format(model.split(':')[0]))
     command(temppath, 'storage', 'juju storage {} --format yaml'.format(model))
     command(temppath, 'storage-pools',
             'juju storage-pools {} --format yaml'.format(model))

--- a/collect.py
+++ b/collect.py
@@ -105,9 +105,9 @@ def main():
         print('Error getting juju status. Aborting.')
         return
 
-    debug_action(temppath, model, status, 'kubernetes-master')
-    debug_action(temppath, model, status, 'kubernetes-worker')
-    debug_action(temppath, model, status, 'etcd')
+    debug_action(temppath, status, model, 'kubernetes-master')
+    debug_action(temppath, status, model, 'kubernetes-worker')
+    debug_action(temppath, status, model, 'etcd')
     # FIXME: no debug action on kubeapi-load-balancer, easyrsa, flannel
 
     command(temppath, 'status', 'juju status {} --format yaml'.format(model))

--- a/collect.py
+++ b/collect.py
@@ -87,7 +87,7 @@ def main():
     options = parse_args()
     model = ""
     if options.model:
-        if len(model.split(':')) != 2:
+        if len(options.model.split(':')) != 2:
             print("Error determining a controller and a model")
             return
         model = "-m {}".format(options.model)
@@ -114,7 +114,7 @@ def main():
     command(temppath, 'debug-log', 'juju debug-log {} --replay'.format(model))
     command(temppath, 'model-config', 'juju model-config {}'.format(model))
     command(temppath, 'controller-debug-log',
-            'juju debug-log {} --replay'.format(model.split(':')[0]))
+            'juju debug-log -m {}:controller --replay'.format(options.model.split(':')[0]))
     command(temppath, 'storage', 'juju storage {} --format yaml'.format(model))
     command(temppath, 'storage-pools',
             'juju storage-pools {} --format yaml'.format(model))


### PR DESCRIPTION
Needed the ability to pass in juju controller:model context rather than relying on juju switch or the current environment in CI tests.

Also did some pep8 formatting

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>